### PR TITLE
[keyvault] style:changed type comment to type annotation

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -2,9 +2,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # -------------------------------------
+from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
+from datetime import datetime
+
 from collections import namedtuple
 from ._shared import parse_key_vault_id
 from ._generated_models import JsonWebKey as _JsonWebKey
+from ._enums import KeyOperation, KeyRotationPolicyAction, KeyType
 
 try:
     from typing import TYPE_CHECKING
@@ -13,10 +17,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
-    from typing import Any, Dict, List, Optional, Union
-    from datetime import datetime
     from . import _generated_models as _models
-    from ._enums import KeyOperation, KeyRotationPolicyAction, KeyType
 
 KeyOperationResult = namedtuple("KeyOperationResult", ["id", "value"])
 
@@ -48,13 +49,11 @@ class JsonWebKey(object):
 
     _FIELDS = ("kid", "kty", "key_ops", "n", "e", "d", "dp", "dq", "qi", "p", "q", "k", "t", "crv", "x", "y")
 
-    def __init__(self, **kwargs):
-        # type: (**Any) -> None
+    def __init__(self, **kwargs: Any) -> None:
         for field in self._FIELDS:
             setattr(self, field, kwargs.get(field))
 
-    def _to_generated_model(self):
-        # type: () -> _JsonWebKey
+    def _to_generated_model(self) -> _JsonWebKey:
         jwk = _JsonWebKey()
         for field in self._FIELDS:
             setattr(jwk, field, getattr(self, field))
@@ -64,8 +63,7 @@ class JsonWebKey(object):
 class KeyProperties(object):
     """A key's id and attributes."""
 
-    def __init__(self, key_id, attributes=None, **kwargs):
-        # type: (str, Optional[_models.KeyAttributes], **Any) -> None
+    def __init__(self, key_id : str, attributes:Optional['_models.KeyAttributes']=None, **kwargs:Any) -> None:
         self._attributes = attributes
         self._id = key_id
         self._vault_id = KeyVaultKeyIdentifier(key_id)
@@ -73,13 +71,11 @@ class KeyProperties(object):
         self._tags = kwargs.get("tags", None)
         self._release_policy = kwargs.pop("release_policy", None)
 
-    def __repr__(self):
-        # type () -> str
+    def __repr__(self) -> str:
         return "<KeyProperties [{}]>".format(self.id)[:1024]
 
     @classmethod
-    def _from_key_bundle(cls, key_bundle):
-        # type: (_models.KeyBundle) -> KeyProperties
+    def _from_key_bundle(cls, key_bundle: '_models.KeyBundle') -> 'KeyProperties':
         """Construct a KeyProperties from an autorest-generated KeyBundle"""
         # pylint:disable=line-too-long
         # release_policy was added in 7.3-preview
@@ -100,10 +96,9 @@ class KeyProperties(object):
             tags=key_bundle.tags,
             release_policy=release_policy,
         )
-
+    
     @classmethod
-    def _from_key_item(cls, key_item):
-        # type: (_models.KeyItem) -> KeyProperties
+    def _from_key_item(cls, key_item: '_models.KeyItem') -> 'KeyProperties':
         """Construct a KeyProperties from an autorest-generated KeyItem"""
         return cls(
             key_id=key_item.kid,  # type: ignore
@@ -113,8 +108,7 @@ class KeyProperties(object):
         )
 
     @property
-    def id(self):
-        # type: () -> str
+    def id(self) -> str:
         """The key's id
 
         :rtype: str
@@ -122,8 +116,7 @@ class KeyProperties(object):
         return self._id
 
     @property
-    def name(self):
-        # type: () -> str
+    def name(self) -> str:
         """The key's name
 
         :rtype: str
@@ -131,8 +124,7 @@ class KeyProperties(object):
         return self._vault_id.name
 
     @property
-    def version(self):
-        # type: () -> Optional[str]
+    def version(self) -> Optional[str]:
         """The key's version
 
         :rtype: str or None
@@ -140,8 +132,7 @@ class KeyProperties(object):
         return self._vault_id.version
 
     @property
-    def enabled(self):
-        # type: () -> Optional[bool]
+    def enabled(self) -> Optional[bool]:
         """Whether the key is enabled for use
 
         :rtype: bool or None
@@ -149,8 +140,7 @@ class KeyProperties(object):
         return self._attributes.enabled if self._attributes else None
 
     @property
-    def not_before(self):
-        # type: () -> Optional[datetime]
+    def not_before(self) -> Optional[datetime]:
         """The time before which the key can not be used, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -158,8 +148,7 @@ class KeyProperties(object):
         return self._attributes.not_before if self._attributes else None
 
     @property
-    def expires_on(self):
-        # type: () -> Optional[datetime]
+    def expires_on(self) -> Optional[datetime]:
         """When the key will expire, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -167,8 +156,7 @@ class KeyProperties(object):
         return self._attributes.expires if self._attributes else None
 
     @property
-    def created_on(self):
-        # type: () -> Optional[datetime]
+    def created_on(self) -> Optional[datetime]:
         """When the key was created, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -176,8 +164,7 @@ class KeyProperties(object):
         return self._attributes.created if self._attributes else None
 
     @property
-    def updated_on(self):
-        # type: () -> Optional[datetime]
+    def updated_on(self) -> Optional[datetime]:
         """When the key was last updated, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -185,8 +172,7 @@ class KeyProperties(object):
         return self._attributes.updated if self._attributes else None
 
     @property
-    def vault_url(self):
-        # type: () -> str
+    def vault_url(self) -> str:
         """URL of the vault containing the key
 
         :rtype: str
@@ -194,8 +180,7 @@ class KeyProperties(object):
         return self._vault_id.vault_url
 
     @property
-    def recoverable_days(self):
-        # type: () -> Optional[int]
+    def recoverable_days(self) -> Optional[int]:
         """The number of days the key is retained before being deleted from a soft-delete enabled Key Vault.
 
         :rtype: int or None
@@ -206,8 +191,7 @@ class KeyProperties(object):
         return None
 
     @property
-    def recovery_level(self):
-        # type: () -> Optional[str]
+    def recovery_level(self) -> Optional[str]:
         """The vault's deletion recovery level for keys
 
         :rtype: str or None
@@ -215,8 +199,7 @@ class KeyProperties(object):
         return self._attributes.recovery_level if self._attributes else None
 
     @property
-    def tags(self):
-        # type: () -> Dict[str, str]
+    def tags(self) -> Dict[str, str]:
         """Application specific metadata in the form of key-value pairs
 
         :rtype: dict[str, str]
@@ -224,8 +207,7 @@ class KeyProperties(object):
         return self._tags
 
     @property
-    def managed(self):
-        # type: () -> Optional[bool]
+    def managed(self) -> Optional[bool]:
         """Whether the key's lifetime is managed by Key Vault. If the key backs a certificate, this will be true.
 
         :rtype: bool or None
@@ -233,8 +215,7 @@ class KeyProperties(object):
         return self._managed
 
     @property
-    def exportable(self):
-        # type: () -> Optional[bool]
+    def exportable(self) -> Optional[bool]:
         """Whether the private key can be exported
 
         :rtype: bool or None
@@ -245,8 +226,7 @@ class KeyProperties(object):
         return None
 
     @property
-    def release_policy(self):
-        # type: () -> Optional[KeyReleasePolicy]
+    def release_policy(self) -> Optional['KeyReleasePolicy']:
         """The :class:`~azure.keyvault.keys.KeyReleasePolicy` specifying the rules under which the key can be exported.
 
         :rtype: ~azure.keyvault.keys.KeyReleasePolicy or None
@@ -267,8 +247,7 @@ class KeyReleasePolicy(object):
         updated after being marked immutable. Release policies are mutable by default.
     """
 
-    def __init__(self, encoded_policy, **kwargs):
-        # type: (bytes, **Any) -> None
+    def __init__(self: bytes, encoded_policy, **kwargs) -> None:
         self.encoded_policy = encoded_policy
         self.content_type = kwargs.get("content_type", None)
         self.immutable = kwargs.get("immutable", None)
@@ -280,8 +259,7 @@ class ReleaseKeyResult(object):
     :ivar str value: A signed token containing the released key.
     """
 
-    def __init__(self, value):
-        # type: (str) -> None
+    def __init__(self, value: str) -> None:
         self.value = value
 
 
@@ -301,8 +279,7 @@ class KeyRotationLifetimeAction(object):
     :paramtype time_before_expiry: Optional[str]
     """
 
-    def __init__(self, action, **kwargs):
-        # type: (KeyRotationPolicyAction, **Any) -> None
+    def __init__(self, action: KeyRotationPolicyAction, **kwargs) -> None:
         self.action = action
         self.time_after_create = kwargs.get("time_after_create", None)
         self.time_before_expiry = kwargs.get("time_before_expiry", None)
@@ -335,8 +312,7 @@ class KeyRotationPolicy(object):
     :vartype updated_on: Optional[~datetime.datetime]
     """
 
-    def __init__(self, **kwargs):
-        # type: (**Any) -> None
+    def __init__(self, **kwargs) -> None:
         self.id = kwargs.get("policy_id", None)
         self.lifetime_actions = kwargs.get("lifetime_actions", [])
         self.expires_in = kwargs.get("expires_in", None)
@@ -393,8 +369,7 @@ class KeyVaultKey(object):
 
     """
 
-    def __init__(self, key_id, jwk=None, **kwargs):
-        # type: (str, Optional[dict], **Any) -> None
+    def __init__(self, key_id: str, jwk: Optional[dict]=None, **kwargs:Any) -> None:
         self._properties = kwargs.pop("properties", None) or KeyProperties(key_id, **kwargs)
         if isinstance(jwk, dict):
             if any(field in kwargs for field in JsonWebKey._FIELDS):  # pylint:disable=protected-access
@@ -405,13 +380,11 @@ class KeyVaultKey(object):
         else:
             self._key_material = JsonWebKey(**kwargs)
 
-    def __repr__(self):
-        # type () -> str
+    def __repr__(self) -> str:
         return "<KeyVaultKey [{}]>".format(self.id)[:1024]
 
     @classmethod
-    def _from_key_bundle(cls, key_bundle):
-        # type: (_models.KeyBundle) -> KeyVaultKey
+    def _from_key_bundle(cls, key_bundle:'_models.KeyBundle') -> 'KeyVaultKey':
         """Construct a KeyVaultKey from an autorest-generated KeyBundle"""
         # pylint:disable=protected-access
         return cls(
@@ -421,8 +394,7 @@ class KeyVaultKey(object):
         )
 
     @property
-    def id(self):
-        # type: () -> str
+    def id(self) -> str:
         """The key's id
 
         :rtype: str
@@ -430,8 +402,7 @@ class KeyVaultKey(object):
         return self._properties.id
 
     @property
-    def name(self):
-        # type: () -> str
+    def name(self) -> str:
         """The key's name
 
         :rtype: str
@@ -439,8 +410,7 @@ class KeyVaultKey(object):
         return self._properties.name
 
     @property
-    def properties(self):
-        # type: () -> KeyProperties
+    def properties(self) -> 'KeyProperties':
         """The key's properties
 
         :rtype: ~azure.keyvault.keys.KeyProperties
@@ -448,8 +418,7 @@ class KeyVaultKey(object):
         return self._properties
 
     @property
-    def key(self):
-        # type: () -> JsonWebKey
+    def key(self) -> JsonWebKey:
         """The JSON web key
 
         :rtype: ~azure.keyvault.keys.JsonWebKey
@@ -457,8 +426,7 @@ class KeyVaultKey(object):
         return self._key_material
 
     @property
-    def key_type(self):
-        # type: () -> Union[str, KeyType]
+    def key_type(self) -> Union[str, KeyType]:
         """The key's type. See :class:`~azure.keyvault.keys.KeyType` for possible values.
 
         :rtype: ~azure.keyvault.keys.KeyType or str
@@ -467,8 +435,7 @@ class KeyVaultKey(object):
         return self._key_material.kty  # type: ignore[attr-defined]
 
     @property
-    def key_operations(self):
-        # type: () -> List[Union[str, KeyOperation]]
+    def key_operations(self) -> List[Union[str, KeyOperation]]:
         """Permitted operations. See :class:`~azure.keyvault.keys.KeyOperation` for possible values.
 
         :rtype: List[~azure.keyvault.keys.KeyOperation or str]
@@ -491,28 +458,23 @@ class KeyVaultKeyIdentifier(object):
             :dedent: 8
     """
 
-    def __init__(self, source_id):
-        # type: (str) -> None
+    def __init__(self, source_id) -> None:
         self._resource_id = parse_key_vault_id(source_id)
 
     @property
-    def source_id(self):
-        # type: () -> str
+    def source_id(self) -> str:
         return self._resource_id.source_id
 
     @property
-    def vault_url(self):
-        # type: () -> str
+    def vault_url(self) -> str:
         return self._resource_id.vault_url
 
     @property
-    def name(self):
-        # type: () -> str
+    def name(self) -> str:
         return self._resource_id.name
 
     @property
-    def version(self):
-        # type: () -> Optional[str]
+    def version(self) -> Optional[str]:
         return self._resource_id.version
 
 
@@ -522,25 +484,22 @@ class DeletedKey(KeyVaultKey):
 
     def __init__(
         self,
-        properties,  # type: KeyProperties
-        deleted_date=None,  # type: Optional[datetime]
-        recovery_id=None,  # type: Optional[str]
-        scheduled_purge_date=None,  # type: Optional[datetime]
-        **kwargs  # type: Any
-    ):
-        # type: (...) -> None
+        properties: 'KeyProperties',
+        deleted_date: Optional[datetime]=None,
+        recovery_id: Optional[str]=None,
+        scheduled_purge_date: Optional[datetime]=None, 
+        **kwargs :Any  
+    ) -> None:
         super(DeletedKey, self).__init__(properties=properties, **kwargs)
         self._deleted_date = deleted_date
         self._recovery_id = recovery_id
         self._scheduled_purge_date = scheduled_purge_date
 
-    def __repr__(self):
-        # type () -> str
+    def __repr__(self) -> str:
         return "<DeletedKey [{}]>".format(self.id)[:1024]
 
     @classmethod
-    def _from_deleted_key_bundle(cls, deleted_key_bundle):
-        # type: (_models.DeletedKeyBundle) -> DeletedKey
+    def _from_deleted_key_bundle(cls, deleted_key_bundle: '_models.DeletedKeyBundle') -> 'DeletedKey':
         """Construct a DeletedKey from an autorest-generated DeletedKeyBundle"""
         # pylint:disable=protected-access
         return cls(
@@ -553,8 +512,7 @@ class DeletedKey(KeyVaultKey):
         )
 
     @classmethod
-    def _from_deleted_key_item(cls, deleted_key_item):
-        # type: (_models.DeletedKeyItem) -> DeletedKey
+    def _from_deleted_key_item(cls, deleted_key_item: '_models.DeletedKeyItem') -> 'DeletedKey':
         """Construct a DeletedKey from an autorest-generated DeletedKeyItem"""
         return cls(
             properties=KeyProperties._from_key_item(deleted_key_item),  # pylint: disable=protected-access
@@ -565,8 +523,7 @@ class DeletedKey(KeyVaultKey):
         )
 
     @property
-    def deleted_date(self):
-        # type: () -> Optional[datetime]
+    def deleted_date(self) -> Optional[datetime]:
         """When the key was deleted, in UTC
 
         :rtype: ~datetime.datetime or None
@@ -574,8 +531,7 @@ class DeletedKey(KeyVaultKey):
         return self._deleted_date
 
     @property
-    def recovery_id(self):
-        # type: () -> Optional[str]
+    def recovery_id(self) -> Optional[str]:
         """An identifier used to recover the deleted key. Returns ``None`` if soft-delete is disabled.
 
         :rtype: str or None
@@ -583,8 +539,7 @@ class DeletedKey(KeyVaultKey):
         return self._recovery_id
 
     @property
-    def scheduled_purge_date(self):
-        # type: () -> Optional[datetime]
+    def scheduled_purge_date(self) -> Optional[datetime]:
         """When the key is scheduled to be purged, in UTC. Returns ``None`` if soft-delete is disabled.
 
         :rtype: ~datetime.datetime or None


### PR DESCRIPTION
# Description

modified azure-sdk-for-python/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py

Update type comment by using type hints for python.
For Testing, changed imports inside of TYPE_CHECKING condition to outside

Closes: #7

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
