### PR TITLE
[ keyvault] Use f-string and dynamic value for error logging not using a static value

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_key_vault_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_key_vault_client.py
@@ -8,7 +8,7 @@
 # Changes may cause incorrect behavior and will be lost if the code is
 # regenerated.
 # --------------------------------------------------------------------------
-
+import sys
 from typing import TYPE_CHECKING
 
 from msrest import Deserializer, Serializer
@@ -23,6 +23,9 @@ from ._operations_mixin import KeyVaultClientOperationsMixin
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
     from typing import Any, Optional
+
+def func_name(): 
+    return sys._getframe(1).f_code.co_name
 
 class _SDKClient(object):
     def __init__(self, *args, **kwargs):
@@ -124,7 +127,7 @@ class KeyVaultClient(KeyVaultClientOperationsMixin, MultiApiClientMixin, _SDKCli
         if api_version == '2016-10-01' or api_version == '7.0' or api_version == '7.1' or api_version == '7.2' or api_version == '7.3':
             base_url = '{vaultBaseUrl}'
         else:
-            raise ValueError("API version {} is not available".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         self._config = KeyVaultClientConfiguration(**kwargs)
         self._client = PipelineClient(base_url=base_url, config=self._config, **kwargs)
         super(KeyVaultClient, self).__init__(

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_operations_mixin.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/_operations_mixin.py
@@ -8,6 +8,7 @@
 # Changes may cause incorrect behavior and will be lost if the code is
 # regenerated.
 # --------------------------------------------------------------------------
+import sys
 from msrest import Serializer, Deserializer
 from typing import TYPE_CHECKING
 
@@ -17,6 +18,8 @@ if TYPE_CHECKING:
 
     from azure.core.paging import ItemPaged
 
+def func_name(): 
+    return sys._getframe(1).f_code.co_name
 
 class KeyVaultClientOperationsMixin(object):
 
@@ -42,11 +45,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.BackupCertificateResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('backup_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'backup_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -85,7 +88,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.BackupKeyResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('backup_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -97,7 +100,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'backup_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -127,13 +130,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.BackupSecretResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('backup_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'backup_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -163,11 +166,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.BackupStorageResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('backup_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'backup_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -200,13 +203,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateOperation
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('create_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'create_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -241,7 +244,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('create_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -253,7 +256,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'create_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -293,7 +296,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyOperationResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('decrypt')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -305,7 +308,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'decrypt'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -336,13 +339,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.DeletedCertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -369,13 +372,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.Contacts
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_certificate_contacts')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_certificate_contacts'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -405,13 +408,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.IssuerBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_certificate_issuer')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_certificate_issuer'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -442,13 +445,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateOperation
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_certificate_operation')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_certificate_operation'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -480,7 +483,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.DeletedKeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -492,7 +495,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -523,13 +526,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SasDefinitionBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_sas_definition')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_sas_definition'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -559,13 +562,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.DeletedSecretBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -592,13 +595,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.StorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -640,7 +643,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyOperationResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('encrypt')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -652,7 +655,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'encrypt'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -685,13 +688,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -718,13 +721,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.Contacts
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificate_contacts')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificate_contacts'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -755,13 +758,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.IssuerBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificate_issuer')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificate_issuer'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -795,13 +798,13 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.paging.ItemPaged[~azure.keyvault.v2016_10_01.models.CertificateIssuerListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificate_issuers')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificate_issuers'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -831,13 +834,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateOperation
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificate_operation')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificate_operation'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -867,13 +870,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificatePolicy
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificate_policy')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificate_policy'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -908,13 +911,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.v2016_10_01.models.CertificateListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificate_versions')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificate_versions'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -946,13 +949,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.v2016_10_01.models.CertificateListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificates')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificates'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -983,13 +986,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.DeletedCertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1024,13 +1027,13 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.paging.ItemPaged[~azure.keyvault.v2016_10_01.models.DeletedCertificateListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_certificates')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_certificates'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1061,7 +1064,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.DeletedKeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -1073,7 +1076,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1108,7 +1111,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.v7_3.models.DeletedKeyListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_keys')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -1120,7 +1123,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_keys'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1153,11 +1156,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.DeletedSasDefinitionBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_sas_definition')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_sas_definition'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1193,11 +1196,11 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.paging.ItemPaged[~azure.keyvault.v7_0.models.DeletedSasDefinitionListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_sas_definitions')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_sas_definitions'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1227,13 +1230,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.DeletedSecretBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1266,13 +1269,13 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.paging.ItemPaged[~azure.keyvault.v2016_10_01.models.DeletedSecretListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_secrets')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_secrets'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1302,11 +1305,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.DeletedStorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1338,11 +1341,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.v7_0.models.DeletedStorageListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_storage_accounts')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_storage_accounts'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1376,7 +1379,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -1388,7 +1391,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1418,11 +1421,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyRotationPolicy
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_key_rotation_policy')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_key_rotation_policy'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1456,7 +1459,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.v7_3.models.KeyListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_key_versions')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -1468,7 +1471,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_key_versions'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1501,7 +1504,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.v7_3.models.KeyListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_keys')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -1513,7 +1516,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_keys'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1542,11 +1545,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.RandomBytes
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_random_bytes')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_random_bytes'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1577,13 +1580,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SasDefinitionBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_sas_definition')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_sas_definition'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1617,13 +1620,13 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.paging.ItemPaged[~azure.keyvault.v2016_10_01.models.SasDefinitionListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_sas_definitions')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_sas_definitions'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1656,13 +1659,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SecretBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1696,13 +1699,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.v2016_10_01.models.SecretListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_secret_versions')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_secret_versions'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1734,13 +1737,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.v2016_10_01.models.SecretListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_secrets')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_secrets'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1768,13 +1771,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.StorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1803,13 +1806,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.v2016_10_01.models.StorageListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_storage_accounts')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_storage_accounts'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1844,13 +1847,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('import_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'import_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1885,7 +1888,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('import_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -1897,7 +1900,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'import_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1931,13 +1934,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('merge_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'merge_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1968,13 +1971,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('purge_deleted_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'purge_deleted_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2005,7 +2008,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('purge_deleted_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -2017,7 +2020,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'purge_deleted_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2048,13 +2051,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('purge_deleted_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'purge_deleted_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2085,11 +2088,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('purge_deleted_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'purge_deleted_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2121,13 +2124,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('recover_deleted_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'recover_deleted_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2159,7 +2162,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('recover_deleted_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -2171,7 +2174,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'recover_deleted_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2205,11 +2208,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.SasDefinitionBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('recover_deleted_sas_definition')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'recover_deleted_sas_definition'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2239,13 +2242,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SecretBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('recover_deleted_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'recover_deleted_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2276,11 +2279,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.StorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('recover_deleted_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'recover_deleted_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2311,13 +2314,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.StorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('regenerate_storage_account_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'regenerate_storage_account_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2353,11 +2356,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyReleaseResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('release')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'release'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2387,11 +2390,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.CertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('restore_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'restore_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2429,7 +2432,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('restore_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -2441,7 +2444,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'restore_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2471,13 +2474,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SecretBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('restore_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'restore_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2507,11 +2510,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.StorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('restore_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'restore_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2543,11 +2546,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('rotate_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'rotate_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2577,13 +2580,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.Contacts
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('set_certificate_contacts')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'set_certificate_contacts'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2616,13 +2619,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.IssuerBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('set_certificate_issuer')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'set_certificate_issuer'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2656,13 +2659,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SasDefinitionBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('set_sas_definition')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'set_sas_definition'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2696,13 +2699,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SecretBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('set_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'set_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2732,13 +2735,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.StorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('set_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'set_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2775,7 +2778,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyOperationResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('sign')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -2787,7 +2790,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'sign'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2825,7 +2828,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyOperationResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('unwrap_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -2837,7 +2840,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'unwrap_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2874,13 +2877,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2913,13 +2916,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.IssuerBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_certificate_issuer')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_certificate_issuer'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2953,13 +2956,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateOperation
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_certificate_operation')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_certificate_operation'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2992,13 +2995,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificatePolicy
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_certificate_policy')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_certificate_policy'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -3036,7 +3039,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -3048,7 +3051,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -3081,11 +3084,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyRotationPolicy
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_key_rotation_policy')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_key_rotation_policy'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -3119,13 +3122,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SasDefinitionBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_sas_definition')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_sas_definition'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -3162,13 +3165,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SecretBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -3199,13 +3202,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.StorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from .v7_0.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -3244,7 +3247,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyVerifyResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('verify')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -3256,7 +3259,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'verify'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -3296,7 +3299,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyOperationResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('wrap_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from .v2016_10_01.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -3308,7 +3311,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from .v7_3.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'wrap_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/aio/_key_vault_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/aio/_key_vault_client.py
@@ -8,7 +8,7 @@
 # Changes may cause incorrect behavior and will be lost if the code is
 # regenerated.
 # --------------------------------------------------------------------------
-
+import sys
 from typing import Any, Optional
 
 from msrest import Deserializer, Serializer
@@ -19,6 +19,9 @@ from azure.profiles.multiapiclient import MultiApiClientMixin
 
 from ._configuration import KeyVaultClientConfiguration
 from ._operations_mixin import KeyVaultClientOperationsMixin
+
+def func_name(): 
+    return sys._getframe(1).f_code.co_name
 
 class _SDKClient(object):
     def __init__(self, *args, **kwargs):
@@ -120,7 +123,7 @@ class KeyVaultClient(KeyVaultClientOperationsMixin, MultiApiClientMixin, _SDKCli
         if api_version == '2016-10-01' or api_version == '7.0' or api_version == '7.1' or api_version == '7.2' or api_version == '7.3':
             base_url = '{vaultBaseUrl}'
         else:
-            raise ValueError("API version {} is not available".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         self._config = KeyVaultClientConfiguration(**kwargs)
         self._client = AsyncPipelineClient(base_url=base_url, config=self._config, **kwargs)
         super(KeyVaultClient, self).__init__(

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/aio/_operations_mixin.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/aio/_operations_mixin.py
@@ -8,11 +8,15 @@
 # Changes may cause incorrect behavior and will be lost if the code is
 # regenerated.
 # --------------------------------------------------------------------------
+import sys
+
 from msrest import Serializer, Deserializer
 from typing import Any, AsyncIterable, Optional
 
 from azure.core.async_paging import AsyncItemPaged
 
+def func_name(): 
+    return sys._getframe(1).f_code.co_name
 
 class KeyVaultClientOperationsMixin(object):
 
@@ -37,11 +41,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.BackupCertificateResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('backup_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'backup_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -79,7 +83,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.BackupKeyResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('backup_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -91,7 +95,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'backup_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -120,13 +124,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.BackupSecretResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('backup_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'backup_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -155,11 +159,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.BackupStorageResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('backup_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'backup_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -191,13 +195,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateOperation
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('create_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'create_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -231,7 +235,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('create_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -243,7 +247,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'create_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -282,7 +286,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyOperationResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('decrypt')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -294,7 +298,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'decrypt'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -324,13 +328,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.DeletedCertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -356,13 +360,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.Contacts
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_certificate_contacts')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_certificate_contacts'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -391,13 +395,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.IssuerBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_certificate_issuer')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_certificate_issuer'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -427,13 +431,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateOperation
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_certificate_operation')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_certificate_operation'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -464,7 +468,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.DeletedKeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -476,7 +480,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -506,13 +510,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SasDefinitionBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_sas_definition')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_sas_definition'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -541,13 +545,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.DeletedSecretBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -573,13 +577,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.StorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('delete_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'delete_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -620,7 +624,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyOperationResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('encrypt')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -632,7 +636,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'encrypt'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -664,13 +668,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -696,13 +700,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.Contacts
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificate_contacts')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificate_contacts'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -732,13 +736,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.IssuerBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificate_issuer')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificate_issuer'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -771,13 +775,13 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.v2016_10_01.models.CertificateIssuerListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificate_issuers')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificate_issuers'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -806,13 +810,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateOperation
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificate_operation')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificate_operation'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -841,13 +845,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificatePolicy
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificate_policy')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificate_policy'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -882,13 +886,13 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.v2016_10_01.models.CertificateListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificate_versions')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificate_versions'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -920,13 +924,13 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.v2016_10_01.models.CertificateListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_certificates')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_certificates'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -956,13 +960,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.DeletedCertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -996,13 +1000,13 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.v2016_10_01.models.DeletedCertificateListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_certificates')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_certificates'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1032,7 +1036,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.DeletedKeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -1044,7 +1048,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1079,7 +1083,7 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.v7_3.models.DeletedKeyListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_keys')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -1091,7 +1095,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_keys'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1123,11 +1127,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.DeletedSasDefinitionBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_sas_definition')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_sas_definition'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1162,11 +1166,11 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.v7_0.models.DeletedSasDefinitionListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_sas_definitions')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_sas_definitions'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1195,13 +1199,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.DeletedSecretBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1233,13 +1237,13 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.v2016_10_01.models.DeletedSecretListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_secrets')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_secrets'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1268,11 +1272,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.DeletedStorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1304,11 +1308,11 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.v7_0.models.DeletedStorageListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_deleted_storage_accounts')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_deleted_storage_accounts'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1341,7 +1345,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -1353,7 +1357,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1382,11 +1386,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyRotationPolicy
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_key_rotation_policy')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_key_rotation_policy'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1419,7 +1423,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.v7_3.models.KeyListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_key_versions')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -1431,7 +1435,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_key_versions'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1463,7 +1467,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.v7_3.models.KeyListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_keys')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -1475,7 +1479,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_keys'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1503,11 +1507,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.RandomBytes
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_random_bytes')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_random_bytes'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1537,13 +1541,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SasDefinitionBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_sas_definition')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_sas_definition'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1576,13 +1580,13 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.v2016_10_01.models.SasDefinitionListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_sas_definitions')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_sas_definitions'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1614,13 +1618,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SecretBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1654,13 +1658,13 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.v2016_10_01.models.SecretListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_secret_versions')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_secret_versions'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1692,13 +1696,13 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.v2016_10_01.models.SecretListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_secrets')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_secrets'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1725,13 +1729,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.StorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1760,13 +1764,13 @@ class KeyVaultClientOperationsMixin(object):
          ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.v2016_10_01.models.StorageListResult]
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('get_storage_accounts')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'get_storage_accounts'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1800,13 +1804,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('import_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'import_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1840,7 +1844,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('import_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -1852,7 +1856,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'import_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1885,13 +1889,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('merge_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'merge_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1921,13 +1925,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('purge_deleted_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'purge_deleted_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1957,7 +1961,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('purge_deleted_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -1969,7 +1973,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'purge_deleted_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -1999,13 +2003,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('purge_deleted_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'purge_deleted_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2035,11 +2039,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('purge_deleted_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'purge_deleted_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2070,13 +2074,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('recover_deleted_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'recover_deleted_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2107,7 +2111,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('recover_deleted_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -2119,7 +2123,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'recover_deleted_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2152,11 +2156,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.SasDefinitionBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('recover_deleted_sas_definition')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'recover_deleted_sas_definition'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2185,13 +2189,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SecretBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('recover_deleted_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'recover_deleted_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2221,11 +2225,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.StorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('recover_deleted_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'recover_deleted_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2255,13 +2259,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.StorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('regenerate_storage_account_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'regenerate_storage_account_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2296,11 +2300,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyReleaseResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('release')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'release'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2329,11 +2333,11 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.CertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('restore_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'restore_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2370,7 +2374,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('restore_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -2382,7 +2386,7 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'restore_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2411,13 +2415,13 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SecretBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('restore_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'restore_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2446,11 +2450,12 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_0.models.StorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('restore_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'restore_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2481,11 +2486,12 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('rotate_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'rotate_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2514,13 +2520,14 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.Contacts
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('set_certificate_contacts')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'set_certificate_contacts'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2552,13 +2559,14 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.IssuerBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('set_certificate_issuer')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'set_certificate_issuer'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2591,13 +2599,14 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SasDefinitionBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('set_sas_definition')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'set_sas_definition'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2630,13 +2639,14 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SecretBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('set_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'set_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2665,13 +2675,14 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.StorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('set_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'set_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2707,7 +2718,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyOperationResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('sign')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -2719,7 +2730,8 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'sign'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2756,7 +2768,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyOperationResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('unwrap_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -2768,7 +2780,8 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'unwrap_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2804,13 +2817,14 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_certificate')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_certificate'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2842,13 +2856,14 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.IssuerBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_certificate_issuer')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_certificate_issuer'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2881,13 +2896,14 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificateOperation
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_certificate_operation')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_certificate_operation'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2919,13 +2935,14 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.CertificatePolicy
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_certificate_policy')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_certificate_policy'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -2962,7 +2979,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -2974,7 +2991,8 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -3006,11 +3024,12 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyRotationPolicy
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_key_rotation_policy')
+        api_version = self._get_api_version(func_name())
         if api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_key_rotation_policy'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -3043,13 +3062,14 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SasDefinitionBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_sas_definition')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_sas_definition'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -3085,13 +3105,14 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.SecretBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_secret')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_secret'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -3121,13 +3142,14 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v2016_10_01.models.StorageBundle
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('update_storage_account')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
             from ..v7_0.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'update_storage_account'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -3165,7 +3187,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyVerifyResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('verify')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -3177,7 +3199,8 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'verify'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config
@@ -3216,7 +3239,7 @@ class KeyVaultClientOperationsMixin(object):
         :rtype: ~azure.keyvault.v7_3.models.KeyOperationResult
         :raises: ~azure.core.exceptions.HttpResponseError
         """
-        api_version = self._get_api_version('wrap_key')
+        api_version = self._get_api_version(func_name())
         if api_version == '2016-10-01':
             from ..v2016_10_01.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         elif api_version == '7.0':
@@ -3228,7 +3251,8 @@ class KeyVaultClientOperationsMixin(object):
         elif api_version == '7.3':
             from ..v7_3.aio.operations import KeyVaultClientOperationsMixin as OperationClass
         else:
-            raise ValueError("API version {} does not have operation 'wrap_key'".format(api_version))
+            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
+
         mixin_instance = OperationClass()
         mixin_instance._client = self._client
         mixin_instance._config = self._config


### PR DESCRIPTION
# Description
The main purpose of this PR is to use f-string and dynamic string values, 
not  using static value
Using of this simple code can generate current function name values
```
import sys
def func_name(): 
    return sys._getframe(1).f_code.co_name
```
So it could help to avoid static value
Because most common error comes from static value

before
``` 
            raise ValueError("API version {} is not available".format(api_version))
```

after
```
            raise ValueError(f"API version {api_version} does not have operation '{func_name()}'")
```

close: #30 

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
