### PR TITLE
[keyvault] style: format to f-string samples/recover_purge_operations_async.py

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations_async.py
@@ -42,18 +42,18 @@ async def run_sample():
     print("\n.. Create keys")
     rsa_key = await client.create_rsa_key("rsaKeyNameAsync")
     ec_key = await client.create_ec_key("ecKeyNameAsync")
-    print("Created key '{0}' of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
-    print("Created key '{0}' of type '{1}'.".format(ec_key.name, ec_key.key_type))
+    print(f"Created key '{rsa_key.name}' of type '{rsa_key.key_type}'")
+    print(f"Created key '{ec_key.name}' of type '{ec_key.key_type}'")
 
     print("\n.. Delete the keys")
     for key_name in (ec_key.name, rsa_key.name):
         deleted_key = await client.delete_key(key_name)
-        print("Deleted key '{0}'".format(deleted_key.name))
+        print(f"Deleted key '{deleted_key.name}'")
 
     # A deleted key can only be recovered if the Key Vault is soft-delete enabled.
     print("\n.. Recover a deleted key")
     recovered_key = await client.recover_deleted_key(rsa_key.name)
-    print("Recovered key '{0}'".format(recovered_key.name))
+    print(f"Recovered key '{recovered_key.name}'")
 
     # To permanently delete the key, the deleted key needs to be purged.
     await client.delete_key(recovered_key.name)
@@ -63,8 +63,7 @@ async def run_sample():
     print("\n.. Purge keys")
     for key_name in (ec_key.name, rsa_key.name):
         await client.purge_deleted_key(key_name)
-        print("Purged '{}'".format(key_name))
-
+        print(f"Purged '{key_name}'")
     print("\nrun_sample done")
     await credential.close()
     await client.close()


### PR DESCRIPTION
# Description
modified azure-sdk-for-python/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations_async.py

Change str.format() to f-string

Close #28

Before:
print("Deleted key '{0}'".format(deleted_key.name))

After:
print(f"Deleted key '{deleted_key.name}'")
Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
