### PR TITLE
[keyvault] style: format to f-string samples/hello_world.py

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py
@@ -48,7 +48,7 @@ key_size = 2048
 key_ops = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
 key_name = "rsaKeyName"
 rsa_key = client.create_rsa_key(key_name, size=key_size, key_operations=key_ops)
-print("RSA Key with name '{0}' created of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
+print(f"RSA Key with name '{rsa_key.name}' created of type '{rsa_key.key_type}'")
 
 # Let's create an Elliptic Curve key with algorithm curve type P-256.
 # if the key already exists in the Key Vault, then a new version of the key is created.
@@ -56,12 +56,12 @@ print("\n.. Create an EC Key")
 key_curve = "P-256"
 key_name = "ECKeyName"
 ec_key = client.create_ec_key(key_name, curve=key_curve)
-print("EC Key with name '{0}' created of type '{1}'.".format(ec_key.name, ec_key.key_type))
+print(f"EC Key with name '{ec_key.name}' created of type '{ec_key.key_type}'")
 
 # Let's get the rsa key details using its name
 print("\n.. Get a Key by its name")
 rsa_key = client.get_key(rsa_key.name)
-print("Key with name '{0}' was found.".format(rsa_key.name))
+print(f"Key with name '{rsa_key.name}' was found.")
 
 # Let's say we want to update the expiration time for the EC key and disable the key to be usable
 # for cryptographic operations. The update method allows the user to modify the metadata (key attributes)
@@ -72,17 +72,15 @@ updated_ec_key = client.update_key_properties(
     ec_key.name, ec_key.properties.version, expires_on=expires, enabled=False
 )
 print(
-    "Key with name '{0}' was updated on date '{1}'".format(updated_ec_key.name, updated_ec_key.properties.updated_on)
+    f"Key with name '{updated_ec_key.name}' was updated on date '{updated_ec_key.properties.updated_on}'"
 )
 print(
-    "Key with name '{0}' was updated to expire on '{1}'".format(
-        updated_ec_key.name, updated_ec_key.properties.expires_on
-    )
+    f"Key with name '{updated_ec_key.name}' was updated to expire on '{updated_ec_key.properties.expires_on}'"
 )
 
 # The RSA key is no longer used, need to delete it from the Key Vault.
 print("\n.. Delete Keys")
 client.begin_delete_key(ec_key.name)
 client.begin_delete_key(rsa_key.name)
-print("Deleted key '{0}'".format(ec_key.name))
-print("Deleted key '{0}'".format(rsa_key.name))
+print(f"Deleted key '{ec_key.name}'")
+print(f"Deleted key '{rsa_key.name}'")


### PR DESCRIPTION
Modified azure-sdk-for-python/sdk/keyvault/azure-keyvault-keys/samples/hello_world.py

Change str.format() to f-string

Close #20

Before
```
print("Deleted key '{0}'".format(rsa_key.name))
```

After
```
print(f"Deleted key '{rsa_key.name}'")
```

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
