### PR TITLE
[keyvault] style: format to f-string samples/recover_purge_operations.py

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations.py
@@ -41,13 +41,13 @@ client = KeyClient(vault_url=VAULT_URL, credential=credential)
 print("\n.. Create keys")
 rsa_key = client.create_rsa_key("rsaKeyName")
 ec_key = client.create_ec_key("ecKeyName")
-print("Created key '{0}' of type '{1}'.".format(rsa_key.name, rsa_key.key_type))
-print("Created key '{0}' of type '{1}'.".format(ec_key.name, ec_key.key_type))
+print(f"Created key '{rsa_key.name}' of type '{rsa_key.key_type}'.")
+print(f"Created key '{ec_key.name}' of type '{ec_key.key_type}'.")
 
 print("\n.. Delete the keys")
 for key_name in (ec_key.name, rsa_key.name):
     client.begin_delete_key(key_name).wait()
-    print("Deleted key '{0}'".format(key_name))
+    print(f"Deleted key '{key_name}'")
 
 # A deleted key can only be recovered if the Key Vault is soft-delete enabled.
 print("\n.. Recover a deleted key")
@@ -56,7 +56,7 @@ recovered_key = recover_key_poller.result()
 
 # This wait is just to ensure recovery is complete before we delete the key again
 recover_key_poller.wait()
-print("Recovered key '{0}'".format(recovered_key.name))
+print(f"Recovered key '{recovered_key.name}'")
 
 # To permanently delete the key, the deleted key needs to be purged.
 # Calling result() on the method will immediately return the `DeletedKey`, but calling wait() blocks
@@ -68,4 +68,4 @@ client.begin_delete_key(recovered_key.name).wait()
 print("\n.. Purge keys")
 for key_name in (ec_key.name, rsa_key.name):
     client.purge_deleted_key(key_name)
-    print("Purged '{}'".format(key_name))
+    print(f"Purged '{key_name}' immediately")


### PR DESCRIPTION
# Description

modified azure-sdk-for-python/sdk/keyvault/azure-keyvault-keys/samples/recover_purge_operations.py

Updated f string formatting and modified purge message

Before:

` print("Purged '{}'".format(key_name))`


After:

`print(f"Purged '{key_name}' immediately")`


# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
