### PR TITLE
[keyvault] style: format to f-string samples/key_rotation.py

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/samples/key_rotation.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/key_rotation.py
@@ -43,7 +43,7 @@ client = KeyClient(vault_url=VAULT_URL, credential=credential)
 # First, create a key
 key_name = "rotation-sample-key"
 key = client.create_rsa_key(key_name)
-print("\nCreated a key; new version is {}".format(key.properties.version))
+print(f"\nCreated a key; new version is {key.properties.version}")
 
 # Set the key's automated rotation policy to rotate the key two months after the key was created.
 # If you pass an empty KeyRotationPolicy() as the `policy` parameter, the rotation policy will be set to the
@@ -62,7 +62,7 @@ for i in range(len(updated_policy.lifetime_actions)):
 assert policy_action, "The specified action should exist in the key rotation policy"
 assert policy_action.time_after_create == "P2M", "The action should have the specified time_after_create"
 assert policy_action.time_before_expiry is None, "The action shouldn't have a time_before_expiry"
-print("\nCreated a new key rotation policy: {} after {}".format(policy_action.action, policy_action.time_after_create))
+print(f"\nCreated a new key rotation policy: {policy_action.action} after {policy_action.time_after_create}")
 
 # Get the key's current rotation policy
 current_policy = client.get_key_rotation_policy(key_name)
@@ -70,7 +70,7 @@ policy_action = None
 for i in range(len(current_policy.lifetime_actions)):
     if current_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
         policy_action = current_policy.lifetime_actions[i]
-print("\nCurrent rotation policy: {} after {}".format(policy_action.action, policy_action.time_after_create))
+print(f"\nCurrent rotation policy: {policy_action.action} after {policy_action.time_after_create}")
 
 # Update the key's automated rotation policy to notify 10 days before the key expires
 new_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P10D")]
@@ -89,11 +89,11 @@ for i in range(len(new_policy.lifetime_actions)):
 assert notify_action, "The specified action should exist in the key rotation policy"
 assert notify_action.time_after_create is None, "The action shouldn't have a time_after_create"
 assert notify_action.time_before_expiry == "P10D", "The action should have the specified time_before_expiry"
-print("\nNew policy action: {} {} before expiry".format(notify_action.action, notify_action.time_before_expiry))
+print(f"\nNew policy action: {notify_action.action} {notify_action.time_before_expiry} before expiry")
 
 # Finally, you can rotate a key on-demand by creating a new version of the key
 rotated_key = client.rotate_key(key_name)
-print("\nRotated the key on-demand; new version is {}".format(rotated_key.properties.version))
+print(f"\nRotated the key on-demand; new version is {rotated_key.properties.version}")
 
 # To clean up, delete the key
 client.begin_delete_key(key_name)


### PR DESCRIPTION
# Description

modified `azure-sdk-for-python/sdk/keyvault/azure-keyvault-keys/samples/key_rotation.py`

Update f string formatting.
See example:

Before:
```python
print("\nCreated a new key rotation policy: {} after {}".format(policy_action.action, policy_action.time_after_create))
```
After:
```python
print(f"\nCurrent rotation policy: {policy_action.action} after {policy_action.time_after_create}")
```

Closes: #38

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.